### PR TITLE
[lfautoinsert] Added map elements for specific languages

### DIFF
--- a/plugins/lfautoinsert.lua
+++ b/plugins/lfautoinsert.lua
@@ -1,6 +1,7 @@
 -- mod-version:1 -- lite-xl 1.16
 local core = require "core"
 local command = require "core.command"
+local common = require "core.common"
 local config = require "core.config"
 local keymap = require "core.keymap"
 
@@ -8,19 +9,51 @@ config.lfautoinsert_map = {
   ["{%s*\n"] = "}",
   ["%(%s*\n"] = ")",
   ["%f[[]%[%s*\n"] = "]",
-  ["%[%[%s*\n"] = "]]",
   ["=%s*\n"] = false,
   [":%s*\n"] = false,
-  ["^#if.*\n"] = "#endif",
-  ["^#else.*\n"] = "#endif",
-  ["%f[%w]do%s*\n"] = "end",
-  ["%f[%w]then%s*\n"] = "end",
-  ["%f[%w]else%s*\n"] = "end",
-  ["%f[%w]repeat%s*\n"] = "until",
-  ["%f[%w]function.*%)%s*\n"] = "end",
+  ["->%s*\n"] = false,
   ["^%s*<([^/][^%s>]*)[^>]*>%s*\n"] = "</$TEXT>",
   ["/%*%s*\n"] = "*/",
+  ["c/c++"] = {
+    file_patterns = {
+      "%.c$", "%.h$", "%.inl$", "%.cpp$", "%.hpp$",
+      "%.cc$", "%.C$", "%.cxx$", "%.c++$", "%.hh$",
+      "%.H$", "%.hxx$", "%.h++$"
+    },
+    map = {
+      ["^#if.*\n"] = "#endif",
+      ["^#else.*\n"] = "#endif",
+    }
+  },
+  ["lua"] = {
+    file_patterns = { "%.lua$" },
+    map = {
+      ["%f[%w]do%s*\n"] = "end",
+      ["%f[%w]then%s*\n"] = "end",
+      ["%f[%w]else%s*\n"] = "end",
+      ["%f[%w]repeat%s*\n"] = "until",
+      ["%f[%w]function.*%)%s*\n"] = "end",
+      ["%[%[%s*\n"] = "]]"
+    }
+  },
 }
+
+local function get_autoinsert_map(filename)
+  local map = {}
+  for pattern, closing in pairs(config.lfautoinsert_map) do
+    if type(closing) == "table" then
+      if common.match_pattern(filename, closing.file_patterns) then
+        for p, e in pairs(closing.map) do
+          map[p] = e
+        end
+      end
+    else
+      map[pattern] = closing
+    end
+  end
+
+  return map
+end
 
 
 local function indent_size(doc, line)
@@ -37,7 +70,7 @@ command.add("core.docview", {
     local line, col = doc:get_selection()
     local text = doc.lines[line - 1]
 
-    for ptn, close in pairs(config.lfautoinsert_map) do
+    for ptn, close in pairs(get_autoinsert_map(doc.filename)) do
       local s, _, str = text:find(ptn)
       if s then
         if  close
@@ -63,4 +96,13 @@ command.add("core.docview", {
 
 keymap.add {
   ["return"] = { "command:submit", "autoinsert:newline" }
+}
+
+return {
+  add = function(file_patterns, map)
+    table.insert(
+      config.lfautoinsert_map,
+      { file_patterns = file_patterns, map=map }
+    )
+  end
 }


### PR DESCRIPTION
Added support of defining elements for specific programming languages by using file patterns and modified default map to use this new feature using some elements only in the languages they should be applied to.