### PR TITLE
[selectionhighlight] added option to not highlight empty spaces.

### DIFF
--- a/plugins/selectionhighlight.lua
+++ b/plugins/selectionhighlight.lua
@@ -5,9 +5,6 @@ local config = require "core.config"
 
 -- originally written by luveti
 
--- Set to true to also highlight empty spaces
-config.highlight_spaces = false
-
 local function draw_box(x, y, w, h, color)
   local r = renderer.draw_rect
   local s = math.ceil(SCALE)
@@ -23,15 +20,7 @@ local draw_line_body = DocView.draw_line_body
 function DocView:draw_line_body(idx, x, y)
   local line1, col1, line2, col2 = self.doc:get_selection(true)
   local selection = self.doc:get_text(line1, col1, line2, col2)
-  if
-    line1 == line2 and col1 ~= col2
-    and
-    (
-      config.highlight_spaces
-      or
-      not selection:match("^%s+$")
-    )
-  then
+  if line1 == line2 and col1 ~= col2 and not selection:match("^%s+$") then
     local lh = self:get_line_height()
     local selected_text = self.doc.lines[line1]:sub(col1, col2 - 1)
     local current_line_text = self.doc.lines[idx]

--- a/plugins/selectionhighlight.lua
+++ b/plugins/selectionhighlight.lua
@@ -1,8 +1,12 @@
 -- mod-version:1 -- lite-xl 1.16
 local style = require "core.style"
 local DocView = require "core.docview"
+local config = require "core.config"
 
 -- originally written by luveti
+
+-- Set to true to also highlight empty spaces
+config.highlight_spaces = false
 
 local function draw_box(x, y, w, h, color)
   local r = renderer.draw_rect
@@ -18,13 +22,24 @@ local draw_line_body = DocView.draw_line_body
 
 function DocView:draw_line_body(idx, x, y)
   local line1, col1, line2, col2 = self.doc:get_selection(true)
-  if line1 == line2 and col1 ~= col2 then
+  local selection = self.doc:get_text(line1, col1, line2, col2)
+  if
+    line1 == line2 and col1 ~= col2
+    and
+    (
+      config.highlight_spaces
+      or
+      not selection:match("^%s+$")
+    )
+  then
     local lh = self:get_line_height()
     local selected_text = self.doc.lines[line1]:sub(col1, col2 - 1)
     local current_line_text = self.doc.lines[idx]
     local last_col = 1
     while true do
-      local start_col, end_col = current_line_text:find(selected_text, last_col, true)
+      local start_col, end_col = current_line_text:find(
+        selected_text, last_col, true
+      )
       if start_col == nil then break end
       local x1 = x + self:get_col_x_offset(idx, start_col)
       local x2 = x + self:get_col_x_offset(idx, end_col + 1)


### PR DESCRIPTION
As the title says, this was annoying on my opinion since any minor selection triggered the highlighting of many empty spaces as shown on the screenshots so added the config option to disable it, better explained on the screenshots:

Without the option:
![2021-06-08_02:01:46](https://user-images.githubusercontent.com/1702572/121132220-dd19ac80-c7fe-11eb-8cc8-9107b84196cc.png)

With the option
![2021-06-08_02:02:15](https://user-images.githubusercontent.com/1702572/121132284-f1f64000-c7fe-11eb-90e1-7fd99efca0b6.png)

And highlight works as normal with non-space characters
![2021-06-08_02:02:32](https://user-images.githubusercontent.com/1702572/121132321-ffabc580-c7fe-11eb-8e30-2663ac4114c7.png)
