### PR TITLE
added smallclock plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Plugin | Description
 *[`scale`](plugins/scale.lua?raw=1)* | Provides support for dynamically adjusting the scale of the code font / UI (`ctrl+-`, `ctrl+=`)
 [`scalestatus`](plugins/scalestatus.lua?raw=1) | Displays current scale (zoom) in status view (depends on scale plugin)
 [`selectionhighlight`](plugins/selectionhighlight.lua?raw=1) | Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*
+[`smallclock`](plugins/smallclock.lua?raw=1) | Displays the current time in the corner of the status view
 [`sort`](plugins/sort.lua?raw=1) | Sorts selected lines alphabetically
 [`spellcheck`](plugins/spellcheck.lua?raw=1) | Underlines misspelt words *([screenshot](https://user-images.githubusercontent.com/3920290/79923973-9caa7400-842e-11ea-85d4-7a196a91ca50.png))* *— note: on Windows a [`words.txt`](https://github.com/dwyl/english-words/blob/master/words.txt) dictionary file must be placed beside the exe*
 [`tabnumbers`](plugins/tabnumbers.lua?raw=1) | Displays tab numbers from 1–9 next to their names *([screenshot](https://user-images.githubusercontent.com/16415678/101285362-007a8500-37e5-11eb-869b-c10eb9d9d902.png))

--- a/plugins/smallclock.lua
+++ b/plugins/smallclock.lua
@@ -1,0 +1,27 @@
+-- lite-xl 1.16
+local core = require "core"
+local style = require "core.style"
+local status_view = require "core.statusview"
+
+local time = ""
+
+core.add_thread(function()
+  while true do
+    local t = os.date("*t")
+    time = string.format("%02d:%02d", t.hour, t.min)
+    coroutine.yield()
+  end
+end)
+
+local get_items = status_view.get_items
+
+function status_view:get_items()
+  local left, right = get_items(self)
+  local t = {style.dim, self.separator2, style.accent, time}
+
+  for _, item in ipairs(t) do
+    table.insert(right, item)
+  end
+
+  return left, right
+end


### PR DESCRIPTION
Smallclock plugin is a tiny plugin that displays the current time in the status bar.