### PR TITLE
Fixed smallclock plugin eating cpu

### DIFF
--- a/plugins/smallclock.lua
+++ b/plugins/smallclock.lua
@@ -9,7 +9,7 @@ core.add_thread(function()
   while true do
     local t = os.date("*t")
     time = string.format("%02d:%02d", t.hour, t.min)
-    coroutine.yield()
+    coroutine.yield(1)
   end
 end)
 


### PR DESCRIPTION
The plugin uses coroutines but did not yield a value, thus the coroutine was called way more often than necessary
Fixed it by simply yielding 1, so it only gets called once per second