### PR TITLE
Add  plugin `linenumbers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Plugin | Description
 [`lfautoinsert`](plugins/lfautoinsert.lua?raw=1) | Automatically inserts indentation and closing bracket/text after newline
 [`linecopypaste`](plugins/linecopypaste.lua?raw=1) | Copy, cut and paste the current line when nothing is selected
 [*`lineguide`*](plugins/lineguide.lua?raw=1) | Displays a line-guide at the line limit offset *([screenshot](https://user-images.githubusercontent.com/3920290/81476159-2cf70000-9208-11ea-928b-9dae3884c477.png))*
+[`linenumbers`](plugins/linenumbers.lua?raw=1) | The ability to change the display of the line number *([screenshot](https://user-images.githubusercontent.com/5556081/129493788-6a4cbd7a-9074-4133-bab7-110ed55f18f7.png))*
 [`linter`](https://github.com/drmargarido/linters)* | Linters for multiple languages
 [`lint+`](https://github.com/liquid600pgm/lintplus)* | Advanced linter with ErrorLens-like error reporting. Compatible with linters made for `linter` *([screenshot](https://raw.githubusercontent.com/liquid600pgm/lintplus/master/screenshots/1.png))*
 [`macmodkeys`](plugins/macmodkeys.lua?raw=1) | Remaps mac modkeys `command/option` to `ctrl/alt`
@@ -109,8 +110,8 @@ Plugin | Description
 ~~[`projectmanager`](plugins/projectmanager.lua?raw=1)~~ | Integrated in lite-xl with improvements ~~Save projects and load/reload them quickly~~
 [`pdfview`](plugins/pdfview.lua?raw=1) | PDF preview for TeX files
 [`rainbowparen`](plugins/rainbowparen.lua?raw=1) | Show nesting of parentheses with rainbow colours
-[`restoretabs`](plugins/restoretabs.lua?raw=1) | Keep a list of recently closed tabs, and restore the tab in order on cntrl+shift+t.
 [`regexreplaceplugin`](plugins/regexreplaceplugin.lua?raw=1) | Allows for you to write a regex and its replacement in one go, and live preview the results.
+[`restoretabs`](plugins/restoretabs.lua?raw=1) | Keep a list of recently closed tabs, and restore the tab in order on cntrl+shift+t.
 *[`scale`](plugins/scale.lua?raw=1)* | Provides support for dynamically adjusting the scale of the code font / UI (`ctrl+-`, `ctrl+=`)
 [`scalestatus`](plugins/scalestatus.lua?raw=1) | Displays current scale (zoom) in status view (depends on scale plugin)
 [`selectionhighlight`](plugins/selectionhighlight.lua?raw=1) | Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*

--- a/plugins/linenumbers.lua
+++ b/plugins/linenumbers.lua
@@ -1,0 +1,85 @@
+-- mod-version:1 -- lite-xl 1.16
+local config = require "core.config"
+local style = require "core.style"
+local DocView = require "core.docview"
+local common = require "core.common"
+local command = require "core.command"
+
+local draw = DocView.draw_line_gutter
+local get_width = DocView.get_gutter_width
+
+function DocView:draw_line_gutter(idx, x, y, width)
+  if not config.line_numbers and not config.relative_line_numbers then
+    return
+  end
+
+  if config.relative_line_numbers then
+
+    local color = style.line_number
+    local local_idx = idx
+    local align = "right"
+
+    local l1 = self.doc:get_selection(false)
+    if idx == l1 then
+      color = style.line_number2
+      if config.line_numbers then
+        align = "center"
+      else
+        local_idx = 0
+      end
+    else
+      local_idx = math.abs(idx - l1)
+    end
+
+    -- Fix for old version (<=1.16)
+    if width == nil then
+      local gpad = style.padding.x * 2
+      local gw = self:get_font():get_width(#self.doc.lines) + gpad
+      width = gpad and gw - gpad or gw
+    end
+
+    common.draw_text(
+      self:get_font(),
+      color, local_idx, align,
+      x + style.padding.x,
+      y + self:get_line_text_y_offset(),
+      width,  self:get_line_height()
+    )
+  else
+    draw(self, idx, x, y, width)
+  end
+end
+
+function DocView:get_gutter_width(...)
+  if not config.line_numbers and not config.relative_line_numbers then
+    return style.padding.x
+  else
+    return get_width(self, ...)
+  end
+end
+
+command.add(nil, {
+  ["line-numbers:toggle"]  = function()
+    config.line_numbers = not config.line_numbers
+  end,
+
+  ["line-numbers:disable"] = function()
+    config.line_numbers = false
+  end,
+
+  ["line-numbers:enable"]  = function()
+    config.line_numbers = true
+  end,
+
+  ["relative-line-numbers:toggle"]  = function()
+    config.relative_line_numbers = not config.relative_line_numbers
+  end,
+
+  ["relative-line-numbers:enable"]  = function()
+    config.relative_line_numbers = true
+  end,
+
+  ["relative-line-numbers:disable"]  = function()
+    config.relative_line_numbers = false
+  end
+})


### PR DESCRIPTION
I decided to write a plugin that would allow not only hiding line numbers, but also making line numbers relative.
Includes the implementation of [hidelinehumbers](https://github.com/lite-xl/lite-plugins/blob/master/plugins/hidelinenumbers.lua) plugin.

However, I'm not sure if the plugin violates compatibility with lite.