### PR TITLE
`selectionhighlight`: Only call `get_text` when needed

### DIFF
--- a/plugins/selectionhighlight.lua
+++ b/plugins/selectionhighlight.lua
@@ -18,22 +18,24 @@ local draw_line_body = DocView.draw_line_body
 
 function DocView:draw_line_body(idx, x, y)
   local line1, col1, line2, col2 = self.doc:get_selection(true)
-  local selection = self.doc:get_text(line1, col1, line2, col2)
-  if line1 == line2 and col1 ~= col2 and not selection:match("^%s+$") then
-    local lh = self:get_line_height()
-    local selected_text = self.doc.lines[line1]:sub(col1, col2 - 1)
-    local current_line_text = self.doc.lines[idx]
-    local last_col = 1
-    while true do
-      local start_col, end_col = current_line_text:find(
-        selected_text, last_col, true
-      )
-      if start_col == nil then break end
-      local x1 = x + self:get_col_x_offset(idx, start_col)
-      local x2 = x + self:get_col_x_offset(idx, end_col + 1)
-      local color = style.selectionhighlight or style.syntax.comment
-      draw_box(x1, y, x2 - x1, lh, color)
-      last_col = end_col + 1
+  if line1 == line2 and col1 ~= col2 then
+    local selection = self.doc:get_text(line1, col1, line2, col2)
+    if not selection:match("^%s+$") then
+      local lh = self:get_line_height()
+      local selected_text = self.doc.lines[line1]:sub(col1, col2 - 1)
+      local current_line_text = self.doc.lines[idx]
+      local last_col = 1
+      while true do
+        local start_col, end_col = current_line_text:find(
+          selected_text, last_col, true
+        )
+        if start_col == nil then break end
+        local x1 = x + self:get_col_x_offset(idx, start_col)
+        local x2 = x + self:get_col_x_offset(idx, end_col + 1)
+        local color = style.selectionhighlight or style.syntax.comment
+        draw_box(x1, y, x2 - x1, lh, color)
+        last_col = end_col + 1
+      end
     end
   end
   draw_line_body(self, idx, x, y)


### PR DESCRIPTION
This avoids calling `get_text` on a potentially big selection.