### PR TITLE
Bring cursor to the new line's end after wrapping

### DIFF
--- a/plugins/autowrap.lua
+++ b/plugins/autowrap.lua
@@ -32,5 +32,6 @@ DocView.on_text_input = function(self, ...)
     command.perform("reflow:reflow")
     command.perform("doc:move-to-next-char")
     command.perform("doc:move-to-previous-char")
+    command.perform("doc:move-to-end-of-line")
   end
 end


### PR DESCRIPTION
After bringing the last word to a newline, add command to move the cursor to the new line's end. This positions the cursor for continuing at the last character typed.