### PR TITLE
Added missing namespace to spellcheck.files config

### DIFF
--- a/plugins/spellcheck.lua
+++ b/plugins/spellcheck.lua
@@ -8,7 +8,7 @@ local DocView = require "core.docview"
 local Doc = require "core.doc"
 
 config.plugins.spellcheck = {}
-config.spellcheck.files = { "%.txt$", "%.md$", "%.markdown$" }
+config.plugins.spellcheck.files = { "%.txt$", "%.md$", "%.markdown$" }
 if PLATFORM == "Windows" then
   config.plugins.spellcheck.dictionary_file = EXEDIR .. "/words.txt"
 else


### PR DESCRIPTION
This entry was missed in #46 which broke the plugin