### PR TITLE
Git status enhancements

### DIFF
--- a/plugins/gitstatus.lua
+++ b/plugins/gitstatus.lua
@@ -8,6 +8,14 @@ local StatusView = require "core.statusview"
 local scan_rate = config.project_scan_rate or 5
 
 
+if TreeView then
+  if not (TreeView["set_color_override"] and TreeView["clear_all_color_overrides"]) then
+    -- TreeView doesn't have the color override feature we rely on, so skip it.
+    TreeView = nil
+  end
+end
+
+
 local git = {
   branch = nil,
   inserts = 0,

--- a/plugins/gitstatus.lua
+++ b/plugins/gitstatus.lua
@@ -70,7 +70,13 @@ core.add_thread(function()
             deletes = deletes + (tonumber(dels) or 0)
             local abs_path = core.project_dir.."/"..root..path
             if TreeView then
-              TreeView:set_color_override(abs_path, style.gitstatus_modification)
+              -- Color this file, and each parent folder,
+              -- so you can see at a glance which folders
+              -- have modified files in them.
+              while abs_path do
+                TreeView:set_color_override(abs_path, style.gitstatus_modification)
+                abs_path = common.dirname(abs_path)
+              end
             end
           end
         end

--- a/plugins/gitstatus.lua
+++ b/plugins/gitstatus.lua
@@ -42,7 +42,7 @@ local function exec(cmd)
   while proc:running() do
     coroutine.yield(0.1)
   end
-  return proc:read_stdout()
+  return proc:read_stdout() or ""
 end
 
 

--- a/plugins/gitstatus.lua
+++ b/plugins/gitstatus.lua
@@ -58,7 +58,7 @@ core.add_thread(function()
       -- get diff
       local diff = exec({"git", "diff", "--numstat"})
       if config.gitstatus.recurse_submodules and system.get_file_info(".gitmodules") then
-        local diff2 = exec({"git", "submodule", "foreach", "git diff --numstat --stat"})
+        local diff2 = exec({"git", "submodule", "foreach", "git diff --numstat"})
         diff = diff .. diff2
       end
 


### PR DESCRIPTION
This PR adds the following enhancements to the `gitstatus` plugin:

- Changes to files within submodules are counted.
- Prevents slow git commands from hanging the application.
- If the TreeView supports color highlighting, changed files are highlighted in the tree view.

The TreeView color highlights require this change: https://github.com/lite-xl/lite-xl/pull/684 but if that feature is not present, or TreeView is not available, this plugin will gracefully skip that feature.

Here is a screenshot showing modified files highlighted in the TreeView:

<img width="390" alt="image" src="https://user-images.githubusercontent.com/169599/142755537-baf9334a-2ddf-4c9f-9155-b15754c09ed8.png">
