### PR TITLE
Don't use subpixel_scale or get_width_subpixel which no longer exist.

### DIFF
--- a/plugins/indentguide.lua
+++ b/plugins/indentguide.lua
@@ -39,10 +39,9 @@ function DocView:draw_line_text(idx, x, y)
   local h = self:get_line_height()
   local sspaces = ""
   local font = self:get_font()
-  local ss = font:subpixel_scale()
   for _ = 0, spaces - 1, config.indent_size do
     local color = style.guide or style.selection
-    local sw = font:get_width_subpixel(sspaces) / ss
+    local sw = font:get_width(sspaces)
     renderer.draw_rect(x + sw, y, w, h, color)
     sspaces = sspaces .. (' '):rep(config.indent_size)
   end


### PR DESCRIPTION
The indentguide plugin does not work with the current main branch of lite-xl. This PR updates it to use the correct API for font sizing.