### PR TITLE
Don't select text when dragging in the minimap.

### DIFF
--- a/plugins/minimap.lua
+++ b/plugins/minimap.lua
@@ -101,7 +101,6 @@ DocView.on_mouse_pressed = function(self, button, x, y, clicks)
 		-- if user didn't click on the visible area (ie not dragging), scroll accordingly
 		if not hit_visible_area then
 			self:scroll_to_line(jump_to_line, false, config.plugins.minimap.instant_scroll)
-			return
 		end
 
 	end


### PR DESCRIPTION
This PR fixes a bug in the minimap scrolling behavior. Prior to this change, if you click and drag in the minimap, outside of the small highlighted section, then large sections of text are selected. This was caused by the DocView.on_mouse_pressed function returning a nil value instead of calling the old on_mouse_pressed function.