### PR TITLE
Minimap highlights selection & caret position

### DIFF
--- a/plugins/minimap.lua
+++ b/plugins/minimap.lua
@@ -222,6 +222,15 @@ DocView.draw_scrollbar = function(self)
 	-- draw visual rect
 	renderer.draw_rect(x, visible_y, w, scroller_height, visual_color)
 
+	-- highlight the selected lines, and the line with the caret on it
+	local selection_line, selection_col, selection_line2, selection_col2 = self.doc:get_selection()
+	local selection_y = y + (selection_line - minimap_start_line) * line_spacing
+	local selection2_y = y + (selection_line2 - minimap_start_line) * line_spacing
+	local selection_min_y = math.min(selection_y, selection2_y)
+	local selection_h = math.abs(selection2_y - selection_y)+1
+	renderer.draw_rect(x, selection_min_y, w, selection_h, style.dim)
+	renderer.draw_rect(x, selection_y, w, line_spacing, style.accent)
+
 	local highlight_align = config.plugins.minimap.highlight_align
 	local highlight_width = config.plugins.minimap.highlight_width
 	local gutter_width = config.plugins.minimap.gutter_width

--- a/plugins/minimap.lua
+++ b/plugins/minimap.lua
@@ -16,6 +16,13 @@ config.plugins.minimap = {
 	-- how many spaces one tab is equivalent to
 	tab_width = 4,
 	draw_background = true,
+
+	-- you can override these colors
+	selection_color = nil,
+	caret_color = nil,
+
+	-- If other plugins provide per-line highlights,
+	-- this controls the placement. (e.g. gitdiff_highlight)
 	highlight_align = 'left',
 	highlight_width = 3,
 	gutter_width = 5,
@@ -223,13 +230,15 @@ DocView.draw_scrollbar = function(self)
 	renderer.draw_rect(x, visible_y, w, scroller_height, visual_color)
 
 	-- highlight the selected lines, and the line with the caret on it
+	local selection_color = config.plugins.minimap.selection_color or style.dim
+	local caret_color = config.plugins.minimap.caret_color or style.caret
 	local selection_line, selection_col, selection_line2, selection_col2 = self.doc:get_selection()
 	local selection_y = y + (selection_line - minimap_start_line) * line_spacing
 	local selection2_y = y + (selection_line2 - minimap_start_line) * line_spacing
 	local selection_min_y = math.min(selection_y, selection2_y)
 	local selection_h = math.abs(selection2_y - selection_y)+1
-	renderer.draw_rect(x, selection_min_y, w, selection_h, style.dim)
-	renderer.draw_rect(x, selection_y, w, line_spacing, style.accent)
+	renderer.draw_rect(x, selection_min_y, w, selection_h, selection_color)
+	renderer.draw_rect(x, selection_y, w, line_spacing, caret_color)
 
 	local highlight_align = config.plugins.minimap.highlight_align
 	local highlight_width = config.plugins.minimap.highlight_width


### PR DESCRIPTION
This PR adds a highlight in the minimap which shows the current caret position and the selected region (if any). The colors for these highlights default to colors from the current theme, but can be individually overridden.

<img width="939" alt="image" src="https://user-images.githubusercontent.com/169599/143731358-43eaf05f-108d-4431-b035-17e8e8114b1c.png">
